### PR TITLE
fix: documentation for the gdrive sample store not matching the tuples

### DIFF
--- a/stores/gdrive/README.md
+++ b/stores/gdrive/README.md
@@ -43,7 +43,7 @@
 - The "Product 2021" folder contains the "Public Roadmap" document
 - The "Product 2021" folder contains the "2021 Roadmap" document
 - Members of the Fabrikam group are viewers of the "Product 2021" folder
-- Anne is a viewer of the "Product 2021" folder
+- Anne is an owner of the "Product 2021" folder
 - Beth is a viewer of the "2021 Roadmap" document
 - Everyone is a viewer of the "Public Roadmap" document
 
@@ -117,7 +117,7 @@ You can see a representation of this model in the JSON syntax accepted by the Op
 | folder:product-2021   | parent   | doc:public-roadmap  | The "Product 2021" folder contains the "Public Roadmap" document       |
 | folder:product-2021   | parent   | doc:2021-roadmap    | The "Product 2021" folder contains the "2021 Roadmap" document         |
 | group:fabrikam#member | viewer   | folder:product-2021 | Members of the Fabrikam group are viewers of the "Product 2021" folder |
-| anne                  | owner    | folder:product-2021 | Anne is a viewer of the "Product 2021" folder                          |
+| anne                  | owner    | folder:product-2021 | Anne is an owner of the "Product 2021" folder                          |
 | beth                  | viewer   | doc:2021-roadmap    | Beth is a viewer of the "2021 Roadmap" document                        |
 | *                     | viewer   | doc:public-roadmap  | Everyone is a viewer of the "Public Roadmap" document                  |
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- fixes https://github.com/openfga/sample-stores/issues/8

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
