### PR TITLE
chore: add modular models example

### DIFF
--- a/stores/modular/README.md
+++ b/stores/modular/README.md
@@ -1,0 +1,13 @@
+# OpenFGA Modular Model Sample Store
+
+* **Title**: **Modular Model** 
+
+## Use-Case
+
+This example showcases how to use modular models to separate your model across multiple files and how to use type extensions within those modules.
+
+## Try It Out
+
+1. Make sure you have the [FGA CLI](https://github.com/openfga/cli/?tab=readme-ov-file#installation)
+
+2. In the `modular` directory, run `fga model test --tests store.fga.yaml`

--- a/stores/modular/core.fga
+++ b/stores/modular/core.fga
@@ -1,0 +1,12 @@
+module core
+
+type user
+
+type organization
+  relations
+    define member: [user] or admin
+    define admin: [user]
+
+type group
+  relations
+    define member: [user]

--- a/stores/modular/fga.mod
+++ b/stores/modular/fga.mod
@@ -2,5 +2,5 @@ schema: '1.2'
 contents:
   - core.fga
   - issue-tracker/projects.fga
-  - issue-tracker//tickets.fga
+  - issue-tracker/tickets.fga
   - wiki.fga

--- a/stores/modular/fga.mod
+++ b/stores/modular/fga.mod
@@ -1,0 +1,6 @@
+schema: '1.2'
+contents:
+  - core.fga
+  - issue-tracker/projects.fga
+  - issue-tracker//tickets.fga
+  - wiki.fga

--- a/stores/modular/issue-tracker/projects.fga
+++ b/stores/modular/issue-tracker/projects.fga
@@ -1,0 +1,10 @@
+module issue-tracker
+
+extend type organization
+  relations
+    define can_create_project: admin
+
+type project
+  relations
+    define organization: [organization]
+    define viewer: member from organization

--- a/stores/modular/issue-tracker/tickets.fga
+++ b/stores/modular/issue-tracker/tickets.fga
@@ -1,0 +1,6 @@
+module issue-tracker
+
+type ticket
+  relations
+    define project: [project]
+    define owner: [user]

--- a/stores/modular/store.fga.yaml
+++ b/stores/modular/store.fga.yaml
@@ -1,0 +1,29 @@
+name: ModularDemo
+model_file: ./fga.mod
+tuples:
+  - user: user:anne
+    relation: admin
+    object: organization:openfga
+  - user: organization:openfga
+    relation: organization
+    object: space:openfga
+  - user: organization:openfga
+    relation: organization
+    object: project:openfga
+tests:
+  - name: Members can view projects
+    check:
+      - user: user:anne
+        object: organization:openfga
+        assertions:
+          admin: true
+          member: true
+          can_create_space: true
+      - user: user:anne
+        object: space:openfga
+        assertions:
+          can_view_pages: true
+      - user: user:anne
+        object: project:openfga
+        assertions:
+          viewer: true

--- a/stores/modular/wiki.fga
+++ b/stores/modular/wiki.fga
@@ -1,0 +1,16 @@
+module wiki
+
+extend type organization
+  relations
+    define can_create_space: admin
+
+
+type space
+  relations
+    define organization: [organization]
+    define can_view_pages: member from organization
+
+type page
+  relations
+    define space: [space]
+    define owner: [user]


### PR DESCRIPTION
## Description

Adds a modular models example, as this is only intended to serve as a partial implementation to demonstrate modular models I removed the atlassian/jira/confluence naming. It could probably be improved to include a condition but I'm not sure where

It doesn't add it to the list to test as the CLI isn't released yet.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
