### PR TITLE
Update the store config file name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone https://github.com/openfga/sample-stores.git openfga-sample-stores && 
 2. Use the `fga` CLI to test the [sample store](#sample-stores) you choose (e.g. `github`, `custom-roles`, etc..)
 ```
 SAMPLE_STORE=github
-fga model test --tests "stores/${SAMPLE_STORE}/store.yaml"
+fga model test --tests "stores/${SAMPLE_STORE}/store.fga.yaml"
 ```
 
 


### PR DESCRIPTION
The store config file has been renamed from `store.yaml` to `store.fga.yaml` in the `README`. 

## Description

The readme uses the `fga cli` to pass the sample store config as a parameter to the cli command. The file name has to be updated for it to work properly.

```sh
$ fga model test --tests "stores/${SAMPLE_STORE}/store.fga.yaml"
```
## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)
-->