### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,4 +1,6 @@
 name: Semgrep
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sample-stores/security/code-scanning/1](https://github.com/openfga/sample-stores/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs a code scan and does not require write access, the permissions should be set to `contents: read`. This ensures that the workflow has only the minimal permissions required to complete its task.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `semgrep` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security permissions for the automated code scanning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->